### PR TITLE
Fix support for devpi-server 6.7+

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -27,7 +27,7 @@ classifiers =
 [options]
 install_requires =
     devpi-common
-    devpi-server>=5.1.0
+    devpi-server>=6.7.0
 package_dir =
     =src
 packages =

--- a/src/devpi_constrained/main.py
+++ b/src/devpi_constrained/main.py
@@ -82,8 +82,8 @@ class ConstrainedStage(object):
         version_filter = constraints.get(project)
         if version_filter is None:
             return
-        for key, href, require_python in links:
-            parts = splitext_archive(key)[0].split('-')
+        for link in links:
+            parts = splitext_archive(link.key)[0].split('-')
             for index in range(1, len(parts)):
                 name = normalize_name('-'.join(parts[:index]))
                 if name != project:

--- a/src/devpi_constrained/main.py
+++ b/src/devpi_constrained/main.py
@@ -83,15 +83,11 @@ class ConstrainedStage(object):
         if version_filter is None:
             return
         for link in links:
-            parts = splitext_archive(link.key)[0].split('-')
-            for index in range(1, len(parts)):
-                name = normalize_name('-'.join(parts[:index]))
-                if name != project:
-                    continue
-                version = '-'.join(parts[index:])
-                if version in version_filter:
-                    yield True
-                    break
+            if link.name != project:
+                continue
+            if link.version in version_filter:
+                yield True
+                break
             else:
                 yield False
 

--- a/src/devpi_constrained/tests/test_constrained.py
+++ b/src/devpi_constrained/tests/test_constrained.py
@@ -68,8 +68,8 @@ def test_invalid_constraints(constrainedindex, mapp, testapp):
         dict(
             result, constraints=['bla,']),
         code=400)
-    assert "Invalid requirement" in r
-    assert "bla," in r
+    assert "Error while parsing constrains" in r
+    assert "\',\'" in r
 
 
 def test_conflicting_constraints(constrainedindex, mapp, testapp):


### PR DESCRIPTION
Hello,

following my report in #3, I spent some time digging how to fix the unittests.
It seems the changes to devpi-server were introduced in version 6.7 and it simplifies the logic needed to extract package name and version.