### PR TITLE
Do not stop yielding links matching filter on first match

### DIFF
--- a/src/devpi_constrained/main.py
+++ b/src/devpi_constrained/main.py
@@ -97,14 +97,13 @@ class ConstrainedStage(object):
                     if version in version_filter:
                         yield True
                         break
-                    else:
-                        yield False
+                else:
+                    yield False
             else:
                 if link_info.name != project:
                     continue
                 if link_info.version in version_filter:
                     yield True
-                    break
                 else:
                     yield False
 

--- a/src/devpi_constrained/tests/test_constrained.py
+++ b/src/devpi_constrained/tests/test_constrained.py
@@ -1,3 +1,5 @@
+import re
+
 import pytest
 from test_devpi_server.conftest import gentmp  # noqa
 from test_devpi_server.conftest import httpget  # noqa
@@ -251,8 +253,14 @@ def test_versions(constrainedindex, constraint, expected, constrain_all, mapp, s
             'constraints=%s' % constraint])
         assert r.json['result']['constraints'] == [constraint]
     r = mapp.get_simple("pkg")
+
+    # Assert all expected versions are listed
     for version in expected:
         assert "pkg-%s.zip" % version in r.text
+
+    # Assert no unexpected versions are listed
+    assert expected == sorted(re.findall(r">pkg-([^<]+)\.zip<", r.text))
+
     releases = sorted(mapp.getreleaseslist("pkg"))
     assert len(releases) == len(expected)
     for release, version in zip(releases, expected):

--- a/src/devpi_constrained/tests/test_constrained.py
+++ b/src/devpi_constrained/tests/test_constrained.py
@@ -236,6 +236,7 @@ def test_simple_projects_all(constrainedindex, mapp, simpypi, testapp):
     ('pkg', ['1.0', '1.1', '2.0']),
     ('pkg>=2', ['2.0']),
     ('pkg<2', ['1.0', '1.1']),
+    ('pkg~=1.0', ['1.0', '1.1']),
     ('pkg==1.1', ['1.1']),
     ('pkg!=1.1', ['1.0', '2.0']),
     ('pkg==1.1', ['1.1'])])


### PR DESCRIPTION
Following the release of version 2.0, I was checking if everything was working as intended. While `devpi list` filtering works as documented in the README, actual usage with pip still does not filter according to constraints correctly.

To test this, I created the constrained index following documentation, then added the following constraint:
```console
$ devpi index -c root/devpi type=constrained bases=root/pypi constraints="tox~=4.0.0"
http://localhost:3141/root/devpi?no_projects=:
  type=constrained
  bases=root/pypi
  volatile=True
  acl_upload=root
  acl_toxresult_upload=:ANONYMOUS:
  constraints=tox~=4.0.0
  mirror_whitelist=
  mirror_whitelist_inheritance=intersection
```

devpi list works as expected:
```console
$ devpi list --all tox
http://localhost:3141/root/pypi/+f/2a5/1d4fd98a93b24/tox-4.0.19-py3-none-any.whl
http://localhost:3141/root/pypi/+f/31d/95663dc66f8d5/tox-4.0.19.tar.gz
http://localhost:3141/root/pypi/+f/2e3/fa6d1b5cc09a9/tox-4.0.18-py3-none-any.whl
http://localhost:3141/root/pypi/+f/e86/2abf5b75aa2d8/tox-4.0.18.tar.gz
[...]
http://localhost:3141/root/pypi/+f/6aa/558b74bb2d96c/tox-4.0.1-py3-none-any.whl
http://localhost:3141/root/pypi/+f/c7c/d95e5e567a7d1/tox-4.0.1.tar.gz
http://localhost:3141/root/pypi/+f/e6a/dcebddfec5e45/tox-4.0.0-py3-none-any.whl
http://localhost:3141/root/pypi/+f/176/43b0e29c41f78/tox-4.0.0.tar.gz
```

but running pip install returned the following unexpected result:
```console
$ pip download --no-deps --index-url=http://localhost:3141/root/devpi tox ; rm tox*.whl
Looking in indexes: http://localhost:3141/root/devpi
Collecting tox
  Downloading http://localhost:3141/root/pypi/%2Bf/e3d/4a65852f029e5/tox-4.4.6-py3-none-any.whl (148 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 149.0/149.0 kB 475.8 MB/s eta 0:00:00
Saved ./tox-4.4.6-py3-none-any.whl
Successfully downloaded tox
```
Removing the `break` fixes the issue as it allows `ConstrainedStage` to filter all versions.
```console
$ pip download --no-deps --index-url=http://localhost:3141/root/devpi tox ; rm tox*.whl
Looking in indexes: http://localhost:3141/root/devpi
Collecting tox
  Downloading http://localhost:3141/root/pypi/%2Bf/2a5/1d4fd98a93b24/tox-4.0.19-py3-none-any.whl (144 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 144.0/144.0 kB 453.8 MB/s eta 0:00:00
Saved ./tox-4.0.19-py3-none-any.whl
Successfully downloaded tox
```

I think the issue came from my PR keeping this break while it was not necessary with `SimpleLinkMeta` since it was addressed at the loop trying to find the proper version split in the tuple-based link info.

I could not find a way to quickly add a test case in the test suite as I am not familiar with Pyramid but if you point me at which function I can use to see the links the same way pip does, I can work on adding it.